### PR TITLE
XST-1875 - Forking SimpleWifi Into our GitHub

### DIFF
--- a/SimpleWifi/SimpleWifi.csproj
+++ b/SimpleWifi/SimpleWifi.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleWifi</RootNamespace>
     <AssemblyName>SimpleWifi</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>
@@ -41,6 +41,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -49,6 +50,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SimpleWifi/Wifi.cs
+++ b/SimpleWifi/Wifi.cs
@@ -31,10 +31,13 @@ namespace SimpleWifi
 		}
 		public void OnQuit()
 		{
-			foreach (var inte in _client.Interfaces)
-				inte.WlanNotification -= inte_WlanNotification;
-			_client.OnQuit();
-			_client = null;
+			foreach (var networkInterface in _client.Interfaces)
+			{
+				networkInterface.WlanNotification -= inte_WlanNotification;
+				_client.OnQuit();
+				_client = null;
+			}
+
 		}
 		/// <summary>
 		/// Returns a list over all available access points

--- a/SimpleWifi/Wifi.cs
+++ b/SimpleWifi/Wifi.cs
@@ -34,10 +34,9 @@ namespace SimpleWifi
 			foreach (var networkInterface in _client.Interfaces)
 			{
 				networkInterface.WlanNotification -= inte_WlanNotification;
-				_client.OnQuit();
-				_client = null;
 			}
-
+			_client.OnQuit();
+			_client = null;
 		}
 		/// <summary>
 		/// Returns a list over all available access points

--- a/SimpleWifi/Wifi.cs
+++ b/SimpleWifi/Wifi.cs
@@ -29,7 +29,13 @@ namespace SimpleWifi
 			foreach (var inte in _client.Interfaces)
 				inte.WlanNotification += inte_WlanNotification;
 		}
-		
+		public void OnQuit()
+		{
+			foreach (var inte in _client.Interfaces)
+				inte.WlanNotification -= inte_WlanNotification;
+			_client.OnQuit();
+			_client = null;
+		}
 		/// <summary>
 		/// Returns a list over all available access points
 		/// </summary>
@@ -61,6 +67,14 @@ namespace SimpleWifi
 			}
 
 			return accessPoints;
+		}
+
+		public void ForceNetworkScan()
+		{
+			foreach (WlanInterface wlanIface in _client.Interfaces)
+			{
+				wlanIface.Scan();
+			}
 		}
 
 		/// <summary>

--- a/SimpleWifi/Win32/Interop/Interop.cs
+++ b/SimpleWifi/Win32/Interop/Interop.cs
@@ -176,6 +176,20 @@ namespace SimpleWifi.Win32.Interop
 			[Out] out IntPtr wlanBssList
 		);
 
+		[DllImport("kernel32", SetLastError = true)]
+		private static extern bool FreeLibrary(IntPtr hModule);
+
+		public static void UnloadImportedDll(string DllPath)
+		{
+			foreach (ProcessModule mod in Process.GetCurrentProcess().Modules)
+			{
+				if (mod.FileName == DllPath)
+				{
+					FreeLibrary(mod.BaseAddress);
+				}
+			}
+		}
+
 		/*
 		 DWORD WlanSetProfileEapUserData(
 			_In_        HANDLE hClientHandle,

--- a/SimpleWifi/Win32/WlanApi.cs
+++ b/SimpleWifi/Win32/WlanApi.cs
@@ -92,9 +92,18 @@ namespace SimpleWifi.Win32
 			try
 			{
 				WlanInterop.WlanCloseHandle(clientHandle, IntPtr.Zero);
+				WlanInterop.UnloadImportedDll("wlanapi.dll");
 			}
 			catch
-			{ }
+			{
+				Console.WriteLine("ERROR FREEING WLAN CLIENT");
+			}
+		}
+
+		public void OnQuit()
+		{
+			WlanInterop.WlanCloseHandle(clientHandle, IntPtr.Zero);
+			WlanInterop.UnloadImportedDll("wlanapi.dll");
 		}
 
 		// Called from interop


### PR DESCRIPTION
- Added the ability to Force a network rescan through the function 'Force Network Rescan()'.
- OnQuit we handle unsubscribing from events and tidying up of objects and running 'WlanCloseHandle'.
- Catching if wlanClient cant quit successfuflly.
- Added the function to unload the .dll associated with Windows Networking (this stops crashes when paired with the Unity editor).
- Updated csproj file to reflect newer versions of tools and frameworks.